### PR TITLE
Fix notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  gem "bullet"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.2)
+    bullet (5.4.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (9.0.5)
     capybara (2.9.1)
       addressable
@@ -207,6 +210,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -223,6 +227,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_votable (~> 0.10.0)
   bootstrap-sass (~> 3.3.5)
+  bullet
   byebug
   capybara
   coffee-rails (~> 4.1.0)
@@ -247,4 +252,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
   end
 
   def index
-    @notifications = current_user.notifications.order('created_at DESC')
+    @notifications = current_user.notifications.includes(:notified_by).order('created_at DESC')
   end
 
   def mark_as_read

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,7 +13,7 @@ class NotificationsController < ApplicationController
     @notification = Notification.find(params[:id])
     @notification.update read: true
     respond_to do |format|
-      format.js
+      format.js {render 'notifications/mark_notification'}
     end
   end
 
@@ -21,7 +21,7 @@ class NotificationsController < ApplicationController
     @notification = Notification.find(params[:id])
     @notification.update read: false
     respond_to do |format|
-      format.js
+      format.js {render 'notifications/mark_notification'}
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,7 @@ class PostsController < ApplicationController
   # GET /posts
   # GET /posts.json
   def index
-    @posts = Post.all.order('created_at DESC').page params[:page]
+    @posts = Post.includes(comments: :user).all.order('created_at DESC').page params[:page]
   end
 
   # GET /posts/1

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,12 +1,12 @@
 module NotificationsHelper
   def marked_notification(notification)
     if notification.read
-      return link_to '', mark_as_unread_path(notification.id), remote: true, id: "mark_as_unread_#{notification.id}",
+      return link_to '', mark_as_unread_path(notification.id), remote: true,
               title: 'Mark as unread',
               class: "glyphicon glyphicon-flag mark-as-read"
 
     else
-      return link_to '', mark_as_read_path(notification.id), remote: true, id: "mark_as_read_#{notification.id}",
+      return link_to '', mark_as_read_path(notification.id), remote: true,
               title: 'Mark as read',
               class: "glyphicon glyphicon-ok mark-as-read"
     end

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,4 +1,4 @@
-%li.single-notification
+%li.single-notification{class: "#{dom_id(notification)}"}
   = link_to "#{notification.notified_by.user_name} has #{notification.notice_type}ed on your post", link_through_path(notification)
   .time-ago
     = time_ago_in_words notification.created_at

--- a/app/views/notifications/mark_as_read.js.erb
+++ b/app/views/notifications/mark_as_read.js.erb
@@ -1,8 +1,0 @@
-$("#mark_as_read_<%= @notification.id %>").removeClass('glyphicon-ok').addClass('glyphicon-flag');
-$("#mark_as_read_<%= @notification.id %>").removeAttr('href').attr('href', '/notifications/<%= @notification.id %>/mark_as_unread');
-$("#mark_as_read_<%= @notification.id %>").removeAttr('title').attr('title', 'Mark as unread');
-$("#mark_as_read_<%= @notification.id %>").html("<%= j (render partial: 'notifications/unread') %>");
-$("#dropdownMenu1").html("<%= j (render partial: 'notifications/counter') %>");
-$("#mark_as_read_<%= @notification.id %>").removeAttr('id').attr('id', 'mark_as_unread_<%= @notification.id %>');
-
-

--- a/app/views/notifications/mark_as_unread.js.erb
+++ b/app/views/notifications/mark_as_unread.js.erb
@@ -1,9 +1,0 @@
-$("#mark_as_unread_<%= @notification.id %>").removeClass('glyphicon-flag').addClass('glyphicon-ok');
-$("#mark_as_unread_<%= @notification.id %>").removeAttr('href').attr('href', '/notifications/<%= @notification.id %>/mark_as_read');
-$("#mark_as_unread_<%= @notification.id %>").removeAttr('title').attr('title', 'Mark as read');
-$("#mark_as_unread_<%= @notification.id %>").removeAttr('id').attr('id', 'mark_as_read_<%= @notification.id %>');
-$("#dropdownMenu1").html("<%= j (render partial: 'notifications/counter') %>");
-$("#mark_as_unread_<%= @notification.id %>").html("<%= j (render partial: 'notifications/unread') %>");
-
-
-

--- a/app/views/notifications/mark_notification.js.erb
+++ b/app/views/notifications/mark_notification.js.erb
@@ -1,0 +1,2 @@
+$(".<%= dom_id @notification %>").replaceWith("<%= j (render @notification) %>");
+$(".notification-dropdown").replaceWith("<%= j (render 'notifications/notification_dropdown') %>");

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  Bullet.enable = true
+  Bullet.alert = true
+  Bullet.console = true
 end


### PR DESCRIPTION
I simplify your notifications code. The issue was generated by multiple dom_ids for each notification row, for example: in *notification-dropdown* you have **mark_as_read_19** as well as in notification-index-list. So, 
```javascript
$("#mark_as_read_19").removeClass('glyphicon-ok').addClass('glyphicon-flag');
```
is applied only for random one DOM element; I change it into class as a result, you can update all rows for notification e.g. 19. I also provide unified class using rails' dom_id. It helps to render whole partial to replace notification row in dropdown and notifications index page. Moreover, I added re-rendering whole dropdown because it showed outdated rows.

I saw a lot of N+1 queries, so I added great gem which should help you.